### PR TITLE
Fix 'The input device is not a TTY' issue in patchman-update

### DIFF
--- a/templates/patchman-update.j2
+++ b/templates/patchman-update.j2
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+export COMPOSE_INTERACTIVE_NO_CLI=1
 docker-compose --no-ansi -f {{ patchman_docker_compose_directory }}/docker-compose.yml exec patchman patchman -q -r -A -p -c -d -n


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>